### PR TITLE
Changed scope="prototype" to scope="default"

### DIFF
--- a/struts2-secure-jakarta-multipart-parser-plugin/src/main/resources/struts-plugin.xml
+++ b/struts2-secure-jakarta-multipart-parser-plugin/src/main/resources/struts-plugin.xml
@@ -26,7 +26,7 @@
   <bean type="org.apache.struts2.dispatcher.multipart.MultiPartRequest"
         class="org.apache.struts.extras.SecureJakartaMultipartParser"
         name="secure-jakarta"
-        scope="prototype"/>
+        scope="default"/>
 
   <!-- Struts 2.3.12+ -->
   <constant name="struts.multipart.parser" value="secure-jakarta"/>

--- a/struts2-secure-jakarta-stream-multipart-parser-plugin/src/main/resources/struts-plugin.xml
+++ b/struts2-secure-jakarta-stream-multipart-parser-plugin/src/main/resources/struts-plugin.xml
@@ -26,7 +26,7 @@
   <bean type="org.apache.struts2.dispatcher.multipart.MultiPartRequest"
         class="org.apache.struts.extras.SecureJakartaStreamMultiPartRequest"
         name="secure-jakarta-stream"
-        scope="prototype"/>
+        scope="default"/>
 
   <constant name="struts.multipart.parser" value="secure-jakarta-stream"/>
 


### PR DESCRIPTION
Prototype scope is from Struts 2.5 but doesn't exist in Struts 2.3.x. Default is the equivalent scope in 2.3.x. This resulted in the list of files uploaded being maintained between requests, which will causes issues when two files of the same name are uploaded.